### PR TITLE
set github actions schedule & tests on Drupal 8.8 to 9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: [pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * THU'
 
 jobs:
   tests-functional:
@@ -9,11 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: [ '8.8', '8.9', '9.0' ]
+        drupal_version: [ '8.8', '8.9', '9.0', '9.1', '9.2' ]
         module: [ 'vercel_deploy' ]
         experimental: [ false ]
         include:
-          - drupal_version: '9.1'
+          - drupal_version: '9.3'
             module: 'vercel_deploy'
             experimental: true
 

--- a/tests/src/Functional/ToolbarTest.php
+++ b/tests/src/Functional/ToolbarTest.php
@@ -20,7 +20,7 @@ class ToolbarTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['toolbar', 'vercel_deploy'];
+  protected static $modules = ['toolbar', 'vercel_deploy'];
 
   /**
    * Tests that the toolbar button is visible.


### PR DESCRIPTION
### 💬 Describe the pull request
- set github actions schedule & tests on Drupal 8.8 to 9.3
- fix deprecation notices