### PR TITLE
add official stable support for drupal 10.4 & 11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: [ 'vercel_deploy' ]
+        experimental: [ false ]
+        include:
+          - drupal_version: '10.5'
+            module: 'home_redirect_lang'
+            experimental: true
+          - drupal_version: '11.2'
+            module: 'home_redirect_lang'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.4']
         module: ['vercel_deploy']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - drop tests support on Drupal <= 9.4
+- remove legacy version annotation on docker-compose.yml
 
 ### Fixed
 - fix phpcs use statements sorted alphabetically
 
 ### Changed
 - run & fix css using stylelintrc from Drupal core
+- update Docker MariaDB 10.3 -> 10.6
 
 ## [1.1.0] - 2022-12-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Drupal GitlabCI
 - add phpstan.neon in order to ignore new static() errors
 - add cpsell prject words for Gitlab-CI
+- add official stable support for drupal 10.4
+- add official stable support for drupal 11.1
 
 ### Removed
 - drop tests support on Drupal <= 9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix phpcs use statements sorted alphabetically
+- fix usage of print_r
 
 ### Changed
 - run & fix css using stylelintrc from Drupal core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
 
   drupal:
@@ -14,7 +12,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.8
+    image: mariadb:10.6
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal

--- a/src/Form/DeployHooksForm.php
+++ b/src/Form/DeployHooksForm.php
@@ -173,7 +173,7 @@ class DeployHooksForm extends ConfirmFormBase {
       $error_operation = reset($operations);
       $messenger->addMessage(new TranslatableMarkup('An error occurred while processing @operation with arguments : @args', [
         '@operation' => $error_operation[0],
-        '@args' => print_r($error_operation[0]),
+        '@args' => print_r($error_operation[0], TRUE),
       ]));
       return;
     }


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4 & 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
